### PR TITLE
Adds season grid view.

### DIFF
--- a/cbbpoll/templates/base.html
+++ b/cbbpoll/templates/base.html
@@ -3,10 +3,13 @@
 {% import "bootstrap/fixes.html" as fixes %}
 {% import "macros.html" as macros %}
 {% set navigation_bar = [
-    (url_for('results'), 'results', 'Results'),
-    (url_for('voters'), 'voters', 'Voters'),
-    (url_for('teams'), 'teams', 'Teams'),
-    (url_for('about'), 'about', 'About')
+    ('results', 'Results', [
+      ('Current Week', url_for('results')),
+      ('Season', url_for('results_overview')),
+    ]),
+    ('voters', 'Voters', url_for('voters')),
+    ('teams', 'Teams', url_for('teams')),
+    ('about', 'About', url_for('about'))
 ] -%}
 {% set active_page = active_page|default('') -%}
 {% block head %}
@@ -45,9 +48,21 @@
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-            {% for href, id, caption in navigation_bar %}
-            <li{% if id == active_page %} class="active"{% endif %}>
-            <a href="{{ href|e }}">{{ caption|e }}</a></li>
+            {% for id, caption, urls in navigation_bar %}
+              {% if urls is string %}
+                <li{% if id == active_page %} class="active"{% endif %}>
+                <a href="{{ urls|e }}">{{ caption|e }}</a></li>
+              {% else %}
+                <li{% if id == active_page %} class="active"{% endif %} class="dropdown">
+                  <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                      aria-expended="false">{{ caption|e }}</a>
+                  <ul class="dropdown-menu" role="menu">
+                    {% for caption, url in urls %}
+                      <li><a href="{{ url|e }}">{{ caption|e }}</a></li>
+                    {% endfor %}
+                  </ul>
+                </li>
+              {% endif %}
             {% endfor %}
           </ul>
           <ul class="nav navbar-nav navbar-right">

--- a/cbbpoll/templates/overview.html
+++ b/cbbpoll/templates/overview.html
@@ -1,0 +1,18 @@
+{# View all the polls from a given season in a grid.
+ # Inputs:
+ # - season: current season year.
+ # - polls_results: list of (poll, results) tuples with completed polls and
+ #                  ranked results.
+ #}
+
+{% extends "base.html" %}
+{% set active_page = "results" %}
+{% block content %}
+<div class="row">
+  <div class="col-md-8">
+    <h1>Results for {{season-1}}-{{season-2000}} Season</h1>
+  </div>
+</div>
+
+{% include 'overviewtable.html' %}
+{% endblock %}

--- a/cbbpoll/templates/overviewtable.html
+++ b/cbbpoll/templates/overviewtable.html
@@ -1,0 +1,70 @@
+{# Shows a set of polls in a grid, weeks on the x-axis, ranks on the y-axis.
+ # Inputs:
+ # - polls_results: list of (poll, results) tuples with completed polls and
+ #                  ranked results.
+ #}
+
+<div class="col-xs-12 col-sm-12 col-md-8 col-lg-8">
+  <table
+      id="overview-table"
+      {# Results table should grow with weeks, not start at 100% #}
+      style="width:auto;"
+      class="results table table-striped table-responsive table-condensed">
+    <tr>
+      <th></th>
+      {% for (poll, _) in polls_results -%}
+      <th style="text-align:center;">
+        <a href="{{ url_for('polls', s=season, w=poll.week) }}">
+          {%- if poll.week == 0 -%}
+          Pre
+          {%- else -%}
+          {{ poll.week }}
+          {%- endif -%}
+        </a>
+      </th>
+      {%- endfor %}
+    </tr>
+
+    {% for zero_based_rank in range(25) %}
+      <tr>
+        <th>{{ zero_based_rank + 1 }}</th>
+
+        {% for (_, results) in polls_results -%}
+          {%- if results[0][zero_based_rank] is defined -%}
+            {%- set team = teams.get(results[0][zero_based_rank][0]) -%}
+            <td data-teamid="{{team.id}}">
+              <span class="team-name">{{team.logo_html(size = 23)|safe}}</span>
+            </td>
+          {% else %}
+            <td></td>
+          {%- endif -%}
+        {%- endfor %}
+        
+        </th>
+      </tr>
+    {% endfor %}
+  </table>
+</div>
+
+<script type="text/javascript">
+window.addEventListener('load', function() {
+  $('#overview-table').delegate('td', 'mouseover mouseout', (function() {
+    var currentHoveredTeamId = 0;
+    var kHighlightCssClass = 'success';
+    return function(e) {
+      if (currentHoveredTeamId) {
+        $('#overview-table td[data-teamid=' + currentHoveredTeamId + ']').
+            removeClass(kHighlightCssClass);
+        currentHoveredTeamId = 0;
+      }
+
+      // Only mouseover sets new hover.
+      if (e.type == 'mouseover') {
+        currentHoveredTeamId = $(this).data('teamid');
+        $('#overview-table td[data-teamid=' + currentHoveredTeamId + ']').
+            addClass(kHighlightCssClass);
+      }
+    };
+  })());
+});
+</script>

--- a/cbbpoll/views.py
+++ b/cbbpoll/views.py
@@ -332,6 +332,30 @@ def results(page=1):
         official_ballots = official_ballots, provisional_ballots = provisional_ballots, page=page, results=results,
         users = User.query, teams=Team.query, closes_eastern = closes_eastern, prov=prov, nonvoters=nonvoters)
 
+@app.route('/overview', methods = ['GET'])
+@app.route('/overview/', methods = ['GET'])
+@app.route('/overview/<int:s>', methods = ['GET'])
+@app.route('/overview/<int:s>/', methods = ['GET'])
+def results_overview(s=0):
+    # If season isn't provided, try to grab the first completed poll.
+    if not s:
+        first_poll = completed_polls().first()
+        if not first_poll:
+            flash('No polls have been completed yet.', 'info')
+            return redirect(url_for('index'))
+        s = first_poll.season
+
+    polls_results = []
+    # Grab all polls for the given season, in order
+    polls = Poll.query.filter_by(season=s).order_by(Poll.week.asc())
+    for poll in polls:
+        polls_results.append((
+            poll,
+            generate_results(poll)))
+
+    return render_template('overview.html', season = s, polls_results = polls_results,
+        teams = Team.query)
+
 @app.route('/ballot/<int:ballot_id>/')
 @app.route('/ballot/<int:ballot_id>')
 def ballot(ballot_id):


### PR DESCRIPTION
Details:
* Makes “Results” in navbar a bootstrap “dropdown”, with “Current Week”
and “Season” options
* “Season” option goes to new “overview” view
* Overview page shows column per week, row per rank. Hovering over a
team highlights that team’s position in the entire table.
* Table HTML itself is separated for later reuse on user page

[Screenshot, hover over BU](https://cloud.githubusercontent.com/assets/769353/5734903/f9176302-9b71-11e4-84b0-6bdcf963f698.png) [note: "Pre" week looks funky because I have no data for that poll, but I do have a "poll" table entry. ]
